### PR TITLE
Replace jgitver with semver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
 
       - run: git fetch --tags --force origin #workaround https://github.com/actions/checkout/issues/882
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4.2.1
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -40,8 +40,8 @@ jobs:
         id: project_version
         run: |
           # Project Version
-          output=$(./gradlew -q version)
-          project_version=$(echo "$output" | grep 'Version:' | awk '{print $2}')
+          output=$(./gradlew -q printVersion)
+          project_version=$(echo "$output" | awk '{print $1}')
           echo "project_version=$project_version" >> "$GITHUB_OUTPUT"
 
       - name: Print Project Version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       publish_version: ${{ steps.project_version.outputs.project_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -25,13 +25,13 @@ jobs:
       - run: git fetch --tags --force origin #workaround https://github.com/actions/checkout/issues/882
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         run: ./gradlew clean build
@@ -60,7 +60,7 @@ jobs:
           shasum -a 256 "converter-${{ steps.project_version.outputs.project_version }}.zip" > "converter-${{ steps.project_version.outputs.project_version }}.zip.sha256"  
 
       - name: Upload distribution artifacts (Release)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: distribution
@@ -77,14 +77,14 @@ jobs:
       contents: write
     steps:
       - name: "Download Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: distribution
           path: converter/build/distributions/
 
       - name: Release
         id: release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/converter/build.gradle
+++ b/converter/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     id 'application'
     alias(libs.plugins.spotless)
-    alias(libs.plugins.jgitver)
+    alias(libs.plugins.semver)
 }
 
 repositories {
@@ -86,4 +86,4 @@ spotless {
     }
 }
 
-jgitver { nonQualifierBranches = "main,master" }
+version = semver.version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ bouncycastle = "1.84"
 tuweni = "2.4.2"
 spotless = "8.4.0"
 progressbar = "0.10.2"
-jgitver = "0.10.0-rc03"
+semver = "0.19.0"
 assertj = "3.27.7"
 teku = "25.12.0"
 
@@ -27,4 +27,4 @@ teku-bls = {module = "tech.pegasys.teku.internal:bls", version.ref = "teku" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-jgitver = { id = "fr.brouillard.oss.gradle.jgitver", version.ref = "jgitver" }
+semver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "semver" }


### PR DESCRIPTION
`jgitver` is not compatible with Gradle configuration cache, which becomes default from Gradle 10.

`semver` is maintained and gained compatibility with `0.12.0`

In my testing, this worked and correctly placed the version into the jar. Note that code with changes since release shows up as 2.0.2-SNAPSHOT, that is by design: https://github.com/jmongard/Git.SemVersioning.Gradle#version-format

CI adjusted for the new `semver` plugin, and uses JDK 25. Bumped all github actions.